### PR TITLE
Add cellular automaton self‑modeling experiment

### DIFF
--- a/ca_experiment/.flake8
+++ b/ca_experiment/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+ignore = E203, W503

--- a/ca_experiment/.github/workflows/ci.yml
+++ b/ca_experiment/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install black flake8
+      - name: Lint with Black
+        run: black --check .
+      - name: Lint with Flake8
+        run: flake8 .
+      - name: Run tests
+        run: pytest --junitxml=reports/junit.xml
+      - name: Run demo
+        run: python demo.py
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ca_experiment_outputs
+          path: |
+            metrics.csv
+            convergence.png
+            gallery/**

--- a/ca_experiment/README.md
+++ b/ca_experiment/README.md
@@ -1,0 +1,30 @@
+# CA Experiment
+
+This project implements a simple cellular automaton "self-modeling" experiment.
+It evolves binary rules toward a target compressibility and visualizes the
+results.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python demo.py
+```
+
+## Tests
+
+```bash
+pytest
+```
+
+## Lint
+
+```bash
+black --check .
+flake8 .
+```

--- a/ca_experiment/ca/__init__.py
+++ b/ca_experiment/ca/__init__.py
@@ -1,0 +1,1 @@
+"""CA experiment package."""

--- a/ca_experiment/ca/analysis.py
+++ b/ca_experiment/ca/analysis.py
@@ -1,0 +1,46 @@
+"""Analysis utilities for cellular automaton experiments."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+import zlib
+
+import numpy as np
+
+from .simulation import run_ca
+
+
+def compressibility(history: np.ndarray) -> float:
+    """Compute compression ratio of CA history using zlib."""
+    bits = np.packbits(history.astype(np.uint8).ravel())
+    data = bits.tobytes()
+    raw_size = len(data)
+    compressed_size = len(zlib.compress(data))
+    return compressed_size / raw_size if raw_size else 0.0
+
+
+def evolve_population(
+    pop: List[np.ndarray], generations: int, target: float = 0.45
+) -> Tuple[List[float], np.ndarray]:
+    """Evolve population of CA rules toward a target compressibility."""
+    scores: List[float] = []
+    best_history: np.ndarray | None = None
+
+    for _ in range(generations):
+        results = []
+        for rule in pop:
+            history = run_ca(rule, size=30, steps=30)
+            score = abs(compressibility(history) - target)
+            results.append((score, history, rule))
+        results.sort(key=lambda x: x[0])
+        best_score, best_history, best_rule = results[0]
+        scores.append(best_score)
+
+        # Create next generation by mutating best rule
+        pop = [best_rule.copy() for _ in pop]
+        for rule in pop:
+            idx = np.random.randint(rule.size)
+            rule[idx] = ~rule[idx]
+
+    assert best_history is not None
+    return scores, best_history

--- a/ca_experiment/ca/simulation.py
+++ b/ca_experiment/ca/simulation.py
@@ -1,0 +1,62 @@
+"""Cellular automaton simulation utilities."""
+
+from typing import Sequence
+
+import numpy as np
+
+
+def step(
+    grid: np.ndarray, birth_mask: Sequence[bool], survival_mask: Sequence[bool]
+) -> np.ndarray:
+    """Perform one CA step using Moore neighborhood.
+
+    Args:
+        grid: 2D boolean array representing the current state.
+        birth_mask: Boolean sequence of length 9 for dead cell birth counts.
+        survival_mask: Boolean sequence of length 9 for alive cell survival counts.
+
+    Returns:
+        Next grid state as a new array.
+    """
+    padded = np.pad(grid, 1, mode="constant").astype(int)
+    neighbors = (
+        padded[:-2, :-2]
+        + padded[:-2, 1:-1]
+        + padded[:-2, 2:]
+        + padded[1:-1, :-2]
+        + padded[1:-1, 2:]
+        + padded[2:, :-2]
+        + padded[2:, 1:-1]
+        + padded[2:, 2:]
+    )
+
+    birth_mask = np.asarray(birth_mask, dtype=bool)
+    survival_mask = np.asarray(survival_mask, dtype=bool)
+    birth = birth_mask[neighbors]
+    survive = survival_mask[neighbors]
+
+    return np.where(grid, survive, birth)
+
+
+def run_ca(rule_bits: np.ndarray, size: int = 200, steps: int = 200) -> np.ndarray:
+    """Run cellular automaton simulation.
+
+    Args:
+        rule_bits: Boolean array of length 18 (birth bits followed by survival).
+        size: Grid size.
+        steps: Number of steps to simulate.
+
+    Returns:
+        History array of shape ``(steps, size, size)``.
+    """
+    rule_bits = np.asarray(rule_bits, dtype=bool).ravel()
+    assert rule_bits.size == 18, "rule_bits must have length 18"
+    birth_mask = rule_bits[:9]
+    survival_mask = rule_bits[9:]
+
+    grid = np.random.rand(size, size) < 0.5
+    history = np.empty((steps, size, size), dtype=bool)
+    for t in range(steps):
+        history[t] = grid
+        grid = step(grid, birth_mask, survival_mask)
+    return history

--- a/ca_experiment/ca/visualize.py
+++ b/ca_experiment/ca/visualize.py
@@ -1,0 +1,30 @@
+"""Visualization utilities for cellular automaton experiments."""
+
+from pathlib import Path
+from typing import List
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_convergence(scores: List[float], out_path: Path) -> None:
+    """Plot convergence of scores over generations."""
+    plt.figure()
+    plt.plot(range(len(scores)), scores, marker="o")
+    plt.xlabel("Generation")
+    plt.ylabel("Best Score")
+    plt.title("Evolution Convergence")
+    plt.tight_layout()
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out_path)
+    plt.close()
+
+
+def save_snapshots(history: np.ndarray, out_dir: Path, per_step: int = 1) -> None:
+    """Save snapshots of CA history to ``out_dir``."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    steps = history.shape[0]
+    for i in range(0, steps, per_step):
+        plt.imsave(out_dir / f"step_{i:03d}.png", history[i], cmap="binary")

--- a/ca_experiment/demo.py
+++ b/ca_experiment/demo.py
@@ -1,0 +1,35 @@
+"""Demo script for CA self-modeling experiment."""
+
+from pathlib import Path
+import csv
+import numpy as np
+
+from ca.analysis import evolve_population
+from ca.visualize import plot_convergence, save_snapshots
+
+
+ndefault_generations = 10
+
+
+def main() -> int:
+    pop_size = 4
+    pop = [np.random.randint(0, 2, 18, dtype=bool) for _ in range(pop_size)]
+
+    scores, history = evolve_population(pop, generations=ndefault_generations)
+
+    with open("metrics.csv", "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["generation", "best_score"])
+        for i, score in enumerate(scores):
+            writer.writerow([i, score])
+
+    plot_convergence(scores, Path("convergence.png"))
+
+    per_step = max(1, history.shape[0] // 10)
+    save_snapshots(history, Path("gallery"), per_step=per_step)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ca_experiment/pyproject.toml
+++ b/ca_experiment/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"

--- a/ca_experiment/requirements.txt
+++ b/ca_experiment/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+matplotlib
+pytest

--- a/ca_experiment/tests/test_analysis.py
+++ b/ca_experiment/tests/test_analysis.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from ca.analysis import compressibility, evolve_population
+
+
+def test_compressibility_limits():
+    frozen = np.zeros((20, 20, 20), dtype=bool)
+    random = np.random.randint(0, 2, (20, 20, 20), dtype=bool)
+    comp_frozen = compressibility(frozen)
+    comp_random = compressibility(random)
+    assert comp_frozen < 0.2
+    assert comp_random > 0.8
+
+
+def test_evolve_population_outputs():
+    pop = [np.random.randint(0, 2, 18, dtype=bool) for _ in range(3)]
+    scores, history = evolve_population(pop, generations=3)
+    assert len(scores) == 3
+    assert history.shape == (30, 30, 30)

--- a/ca_experiment/tests/test_simulation.py
+++ b/ca_experiment/tests/test_simulation.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from ca.simulation import run_ca, step
+
+
+def test_step_blinker_block():
+    birth = [False] * 9
+    birth[3] = True
+    survival = [False] * 9
+    survival[2] = True
+    survival[3] = True
+
+    blinker = np.array([[0, 0, 0], [1, 1, 1], [0, 0, 0]], dtype=bool)
+    blinker_next = np.array([[0, 1, 0], [0, 1, 0], [0, 1, 0]], dtype=bool)
+    result = step(blinker, birth, survival)
+    assert np.array_equal(result, blinker_next)
+
+    block = np.array([[1, 1], [1, 1]], dtype=bool)
+    result_block = step(block, birth, survival)
+    assert np.array_equal(result_block, block)
+
+
+def test_run_ca_shape():
+    rule = np.random.randint(0, 2, 18, dtype=bool)
+    hist = run_ca(rule, size=10, steps=5)
+    assert hist.shape == (5, 10, 10)

--- a/ca_experiment/tests/test_visualize.py
+++ b/ca_experiment/tests/test_visualize.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import numpy as np
+
+from ca.visualize import plot_convergence, save_snapshots
+
+
+def test_visual_outputs(tmp_path: Path):
+    scores = [0.5, 0.4, 0.3]
+    out_png = tmp_path / "conv.png"
+    plot_convergence(scores, out_png)
+    assert out_png.exists()
+
+    history = np.random.randint(0, 2, (5, 5, 5), dtype=bool)
+    out_dir = tmp_path / "snaps"
+    save_snapshots(history, out_dir, per_step=2)
+    files = list(out_dir.glob("*.png"))
+    assert files


### PR DESCRIPTION
## Summary
- implement CA simulation, analysis, and visualization modules
- add demo script that evolves CA rules and outputs metrics and images
- configure Black and isort formatting, add flake8 rules
- set up GitHub Actions workflow for linting, testing, and running demo
- provide unit tests for simulation, analysis and visualization

## Testing
- `black . --check`
- `flake8 .`
- `pytest -q`
- `python demo.py`

------
https://chatgpt.com/codex/tasks/task_e_686d80fb1fc88327a1e03803f5f43a3a