### PR TITLE
Add tests for CA convergence

### DIFF
--- a/ca_experiment/tests/test_analysis.py
+++ b/ca_experiment/tests/test_analysis.py
@@ -17,3 +17,12 @@ def test_evolve_population_outputs():
     scores, history = evolve_population(pop, generations=3)
     assert len(scores) == 3
     assert history.shape == (30, 30, 30)
+
+
+def test_evolve_population_improves_score():
+    np.random.seed(0)
+    pop = [np.random.randint(0, 2, 18, dtype=bool) for _ in range(4)]
+    scores, history = evolve_population(pop, generations=5, target=0.45)
+    assert scores[-1] <= scores[0]
+    final_comp = compressibility(history)
+    assert abs(final_comp - 0.45) < 0.2

--- a/ca_experiment/tests/test_simulation.py
+++ b/ca_experiment/tests/test_simulation.py
@@ -24,3 +24,9 @@ def test_run_ca_shape():
     rule = np.random.randint(0, 2, 18, dtype=bool)
     hist = run_ca(rule, size=10, steps=5)
     assert hist.shape == (5, 10, 10)
+
+
+def test_run_ca_all_dead():
+    rule_bits = np.zeros(18, dtype=bool)
+    history = run_ca(rule_bits, size=5, steps=3)
+    assert not history[-1].any()


### PR DESCRIPTION
## Summary
- add a convergence test for `evolve_population`
- check that CA rules with no births or survival die out

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d854bdb108327948ad5fa689de424